### PR TITLE
Fix UDP reuseport test to accept either socket

### DIFF
--- a/pingora-core/src/listeners/mod.rs
+++ b/pingora-core/src/listeners/mod.rs
@@ -31,12 +31,27 @@ use async_trait::async_trait;
 use pingora_error::Result;
 use std::{fs::Permissions, sync::Arc};
 
-use l4::{ListenerEndpoint, Stream as L4Stream};
+use l4::Stream as L4Stream;
 use tls::{Acceptor, TlsSettings};
 
+pub use crate::protocols::l4::datagram::Datagram;
 pub use crate::protocols::tls::ALPN;
 use crate::protocols::GetSocketDigest;
-pub use l4::{ServerAddress, TcpSocketOptions};
+pub use l4::{
+    ListenerEndpoint, ListenerEndpointBuilder, ServerAddress, TcpSocketOptions, UdpSocketOptions,
+};
+
+/// Create a builder for a UDP listening endpoint with default socket options.
+pub fn udp(addr: &str) -> ListenerEndpointBuilder {
+    udp_with_options(addr, None)
+}
+
+/// Create a builder for a UDP listening endpoint with the provided socket options.
+pub fn udp_with_options(addr: &str, sock_opt: Option<UdpSocketOptions>) -> ListenerEndpointBuilder {
+    let mut builder = ListenerEndpoint::builder();
+    builder.listen_addr(ServerAddress::Udp(addr.into(), sock_opt));
+    builder
+}
 
 /// The APIs to customize things like certificate during TLS server side handshake
 #[async_trait]

--- a/pingora-core/src/protocols/l4/datagram.rs
+++ b/pingora-core/src/protocols/l4/datagram.rs
@@ -1,0 +1,153 @@
+// Copyright 2025 Cloudflare, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Datagram wrapper for UDP packets.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawSocket;
+
+use async_trait::async_trait;
+use tokio::net::UdpSocket;
+
+use crate::protocols::digest::{
+    GetProxyDigest, GetSocketDigest, GetTimingDigest, SocketDigest, TimingDigest,
+};
+use crate::protocols::l4::socket::SocketAddr;
+use crate::protocols::{raw_connect::ProxyDigest, Shutdown, UniqueID, UniqueIDType};
+
+/// Maximum UDP datagram payload size we allocate for when reading.
+const MAX_DATAGRAM_CAPACITY: usize = 65_535;
+
+/// Representation of a single UDP datagram received from a listener.
+#[derive(Debug)]
+pub struct Datagram {
+    socket: Arc<UdpSocket>,
+    payload: Vec<u8>,
+    source: std::net::SocketAddr,
+    destination: std::net::SocketAddr,
+    socket_digest: Arc<SocketDigest>,
+    received: SystemTime,
+    proxy_digest: Option<Arc<ProxyDigest>>,
+}
+
+impl Datagram {
+    pub(crate) async fn receive(socket: &Arc<UdpSocket>) -> std::io::Result<Self> {
+        let mut buf = vec![0u8; MAX_DATAGRAM_CAPACITY];
+        let (len, source) = socket.recv_from(&mut buf).await?;
+        buf.truncate(len);
+
+        let destination = socket.local_addr()?;
+        let owned_socket = Arc::clone(socket);
+
+        #[cfg(unix)]
+        let digest = SocketDigest::from_raw_fd(owned_socket.as_raw_fd());
+        #[cfg(windows)]
+        let digest = SocketDigest::from_raw_socket(owned_socket.as_raw_socket());
+
+        let _ = digest.peer_addr.set(Some(SocketAddr::Inet(source)));
+        let _ = digest.local_addr.set(Some(SocketAddr::Inet(destination)));
+
+        Ok(Datagram {
+            socket: owned_socket,
+            payload: buf,
+            source,
+            destination,
+            socket_digest: Arc::new(digest),
+            received: SystemTime::now(),
+            proxy_digest: None,
+        })
+    }
+
+    /// Access the underlying UDP socket.
+    pub fn socket(&self) -> Arc<UdpSocket> {
+        Arc::clone(&self.socket)
+    }
+
+    /// Immutable reference to the payload bytes for this datagram.
+    pub fn data(&self) -> &[u8] {
+        &self.payload
+    }
+
+    /// Consume the datagram, returning the underlying socket and payload.
+    pub fn into_parts(
+        self,
+    ) -> (
+        Arc<UdpSocket>,
+        Vec<u8>,
+        std::net::SocketAddr,
+        std::net::SocketAddr,
+    ) {
+        (self.socket, self.payload, self.source, self.destination)
+    }
+
+    /// Source address of the datagram.
+    pub fn source(&self) -> std::net::SocketAddr {
+        self.source
+    }
+
+    /// Destination address the datagram was received on.
+    pub fn destination(&self) -> std::net::SocketAddr {
+        self.destination
+    }
+}
+
+#[async_trait]
+impl Shutdown for Datagram {
+    async fn shutdown(&mut self) {}
+}
+
+impl UniqueID for Datagram {
+    #[cfg(unix)]
+    fn id(&self) -> UniqueIDType {
+        self.socket.as_raw_fd()
+    }
+
+    #[cfg(windows)]
+    fn id(&self) -> UniqueIDType {
+        self.socket.as_raw_socket() as UniqueIDType
+    }
+}
+
+impl GetSocketDigest for Datagram {
+    fn get_socket_digest(&self) -> Option<Arc<SocketDigest>> {
+        Some(self.socket_digest.clone())
+    }
+
+    fn set_socket_digest(&mut self, socket_digest: SocketDigest) {
+        self.socket_digest = Arc::new(socket_digest);
+    }
+}
+
+impl GetTimingDigest for Datagram {
+    fn get_timing_digest(&self) -> Vec<Option<TimingDigest>> {
+        vec![Some(TimingDigest {
+            established_ts: self.received,
+        })]
+    }
+}
+
+impl GetProxyDigest for Datagram {
+    fn get_proxy_digest(&self) -> Option<Arc<ProxyDigest>> {
+        self.proxy_digest.clone()
+    }
+
+    fn set_proxy_digest(&mut self, digest: ProxyDigest) {
+        self.proxy_digest = Some(Arc::new(digest));
+    }
+}

--- a/pingora-core/src/protocols/l4/mod.rs
+++ b/pingora-core/src/protocols/l4/mod.rs
@@ -14,6 +14,7 @@
 
 //! Transport layer protocol implementation
 
+pub mod datagram;
 pub mod ext;
 pub mod listener;
 pub mod socket;

--- a/pingora-core/tests/listener_udp.rs
+++ b/pingora-core/tests/listener_udp.rs
@@ -1,0 +1,84 @@
+use pingora_core::listeners;
+
+#[cfg(unix)]
+use pingora_core::listeners::UdpSocketOptions;
+
+#[tokio::test]
+async fn udp_endpoint_receives_datagram() {
+    let builder = listeners::udp("127.0.0.1:0");
+
+    #[cfg(unix)]
+    let endpoint = builder.listen(None).await.expect("binds UDP endpoint");
+
+    #[cfg(windows)]
+    let endpoint = builder.listen().await.expect("binds UDP endpoint");
+
+    let local_addr = endpoint
+        .udp_socket()
+        .expect("listener exposes UDP socket")
+        .local_addr()
+        .expect("has local addr");
+
+    let sender = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("bind sender");
+    let payload = b"integration".to_vec();
+    sender
+        .send_to(&payload, local_addr)
+        .await
+        .expect("send datagram");
+
+    let datagram = endpoint.recv_datagram().await.expect("receive datagram");
+    assert_eq!(datagram.data(), payload.as_slice());
+    assert_eq!(datagram.source(), sender.local_addr().unwrap());
+    assert_eq!(datagram.destination(), local_addr);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn udp_endpoint_supports_reuseport() {
+    let mut reuse_options = UdpSocketOptions::default();
+    reuse_options.so_reuseaddr = Some(true);
+    reuse_options.so_reuseport = Some(true);
+
+    let builder1 = listeners::udp_with_options("127.0.0.1:0", Some(reuse_options.clone()));
+
+    let endpoint1 = builder1
+        .listen(None)
+        .await
+        .expect("binds first UDP endpoint");
+
+    let bound_addr = endpoint1
+        .udp_socket()
+        .expect("udp socket available")
+        .local_addr()
+        .expect("has local addr");
+
+    let addr_str = bound_addr.to_string();
+    let builder2 = listeners::udp_with_options(&addr_str, Some(reuse_options));
+
+    let endpoint2 = builder2
+        .listen(None)
+        .await
+        .expect("binds second UDP endpoint");
+
+    let sender = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("bind sender");
+    sender
+        .send_to(b"payload", bound_addr)
+        .await
+        .expect("send datagram");
+
+    let recv1 = endpoint1.recv_datagram();
+    let recv2 = endpoint2.recv_datagram();
+
+    tokio::select! {
+        res = recv1 => {
+            res.expect("endpoint 1 receives datagram");
+        }
+        res = recv2 => {
+            res.expect("endpoint 2 receives datagram");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update the UDP reuseport integration test to await whichever endpoint receives the datagram first using `tokio::select!`

## Testing
- cargo test -p pingora-core udp_endpoint_supports_reuseport -- --test-threads=1

------
https://chatgpt.com/codex/tasks/task_e_68e5ab7abe788333b0d1515a277a60ac