### PR TITLE
Fix UDP reuseport test to await either listener

### DIFF
--- a/pingora-core/src/listeners/l4.rs
+++ b/pingora-core/src/listeners/l4.rs
@@ -695,7 +695,14 @@ mod test {
         sender.send_to(b"data", bound_addr).await.unwrap();
 
         // Ensure at least one of the sockets can receive traffic.
-        let _ = endpoint1.recv_datagram().await.unwrap();
+        tokio::select! {
+            res = endpoint1.recv_datagram() => {
+                res.unwrap();
+            }
+            res = endpoint2.recv_datagram() => {
+                res.unwrap();
+            }
+        }
         drop(endpoint2);
     }
 }


### PR DESCRIPTION
## Summary
- prevent `test_listen_udp_reuseport` from hanging by waiting for a datagram on either endpoint using `tokio::select!`

## Testing
- `cargo test -p pingora-core test_listen_udp_reuseport`


------
https://chatgpt.com/codex/tasks/task_e_68e60e47de2c8333a95e8a3ad3cb994f